### PR TITLE
ENH: ticker price get cron lambda

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "127.0.0.1:4566:4566"
       - "127.0.0.1:4571:4571"
     environment:
-      - SERVICES=dynamodb,lambda,apigateway,cloudformation,iam,s3
+      - SERVICES=dynamodb,lambda,apigateway,cloudformation,iam,s3,events
       - DEFAULT_REGION=eu-west-2
       - DEBUG=1
       - DATA_DIR=${DATA_DIR- }

--- a/lambdas/create-ticker-prices-cron/app.js
+++ b/lambdas/create-ticker-prices-cron/app.js
@@ -1,0 +1,79 @@
+const AWS = require('aws-sdk');
+const CoinGecko = require('coingecko-api');
+const { v4: uuidv4 } = require('uuid');
+const TickerTableName = process.env.TICKER_TABLE;
+const TickerPriceTableName = process.env.TICKER_PRICE_TABLE_NAME;
+
+// TODO: move to utils / shared location
+let dynamoDbClient;
+const makeClient = () => {
+    const options = {
+        region: 'eu-west-2'
+    };
+    if(process.env.LOCALSTACK_HOSTNAME) {
+        options.endpoint = `http://${process.env.LOCALSTACK_HOSTNAME}:${process.env.EDGE_PORT}`;
+    }
+    console.log(`Connecting to AWS DynamoDB at ${options.endpoint}`)
+    dynamoDbClient = new AWS.DynamoDB(options);
+    return dynamoDbClient;
+};
+const dbClient = makeClient()
+
+const CoinGeckoClient = new CoinGecko();
+
+let response;
+exports.handler = async (event, context) => {
+    try {
+        console.log('Received event:', JSON.stringify(event, null, 2));
+
+        // get all tickers
+        var scanParams = {
+            TableName: TickerTableName
+        };
+        tickers = await dbClient.scan(scanParams).promise();
+
+        console.log(tickers);
+        console.log(tickers.Items[0]);
+        console.log(tickers.Items[0]['coinId']);
+
+        await Promise.all(tickers.Items.map(async (t) => {
+            var coinData = await CoinGeckoClient.simple.price({
+                ids: t['coinId']['S'],
+                vs_currencies: 'gbp'
+            });
+            console.log(coinData);
+            var putParams = {
+                TableName: TickerPriceTableName,
+                Item: {
+                    'id': {
+                        S: uuidv4()
+                    },
+                    'tickerId': {
+                        S: t['id']['S']
+                    },
+                    'datetime': {
+                        S: new Date().toISOString()
+                    },
+                    'price': {
+                        N: `${coinData['data'][t['coinId']['S']]['gbp']}`
+                    }
+                }
+            };
+            console.log(putParams);
+            await dbClient.putItem(putParams).promise();
+            // await dbClient.put(putParams).promise();
+        }))
+        // tickers.forEach(e => async )
+
+        // var coinData = await CoinGeckoClient.simple.price({
+        //     ids: tickers.Items[0]['coinId']['S'],
+        //     vs_currencies: 'gbp'
+        // })
+
+        // console.log(coinData);
+
+        // Promise.all(tickers.Items.map((t) => createTickerPrice(t['coinId']['S'], t['id']['S'])));
+    } catch (err) {
+        console.log(err);
+    }
+};

--- a/lambdas/create-ticker-prices-cron/package-lock.json
+++ b/lambdas/create-ticker-prices-cron/package-lock.json
@@ -1,0 +1,114 @@
+{
+    "name": "finance-dash-server-create-ticker-prices-cron",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "aws-sdk": {
+            "version": "2.973.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.973.0.tgz",
+            "integrity": "sha512-IhVDIrI+7x+643S7HKDZ8bA8rTKfkCLSlxUZcP9W39PD5y04Hwamxou/kNTtXzdg1yyriq3d5tCVu6w5Z5QFDQ==",
+            "requires": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                }
+            }
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "coingecko-api": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/coingecko-api/-/coingecko-api-1.0.10.tgz",
+            "integrity": "sha512-7YLLC85+daxAw5QlBWoHVBVpJRwoPr4HtwanCr8V/WRjoyHTa1Lb9DQAvv4MDJZHiz4no6HGnDQnddtjV35oRA=="
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "jmespath": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+        },
+        "punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        },
+        "sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+    }
+}

--- a/lambdas/create-ticker-prices-cron/package.json
+++ b/lambdas/create-ticker-prices-cron/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "finance-dash-server-create-ticker-prices-cron",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "Robbie Dunn",
+    "dependencies": {
+        "aws-sdk": "*",
+        "coingecko-api": "^1.0.10",
+        "uuid": "*"
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,12 +58,44 @@
         "constructs": "^3.3.69"
       }
     },
+    "@aws-cdk/aws-autoscaling": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.117.0.tgz",
+      "integrity": "sha512-R18vpfP1MXgDeU8YOOTZC5SypXFZ4meS2N/PLclM3TAAhe9/bAGD6cFe74auIgH+BM7AcOpIB9uQFKStkgCHLA==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "1.117.0",
+        "@aws-cdk/aws-cloudwatch": "1.117.0",
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.117.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-sns": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "@aws-cdk/aws-autoscaling-common": {
       "version": "1.117.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.117.0.tgz",
       "integrity": "sha512-kC/ATb0Lt7H0CbJ4nBLDHv9E3z/rUASjqfjaclgh/xpB22/pOK3XeSZVJyy2h4ZDVSsglTsHt2ZcW+NYQvsAeA==",
       "requires": {
         "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-hooktargets": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.117.0.tgz",
+      "integrity": "sha512-itWEXwhmdl0m7RhHKLWDdTu+mSx12sk28OIQv89WrOXuWeWjiGISEa76B+lRkznknewf7crsBnwsxEpaMIoQsQ==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-lambda": "1.117.0",
+        "@aws-cdk/aws-sns": "1.117.0",
+        "@aws-cdk/aws-sns-subscriptions": "1.117.0",
+        "@aws-cdk/aws-sqs": "1.117.0",
         "@aws-cdk/core": "1.117.0",
         "constructs": "^3.3.69"
       }
@@ -95,11 +127,70 @@
         "constructs": "^3.3.69"
       }
     },
+    "@aws-cdk/aws-cloudfront": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.117.0.tgz",
+      "integrity": "sha512-HGbg9Zyw4xT+iqva5wqhR2MA8EQdslLxAp9Rxpgu6+3xh5zRaFyjzIWR8/e1EmdhtefnyUdUup8XFCklTwsZyA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.117.0",
+        "@aws-cdk/aws-cloudwatch": "1.117.0",
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-lambda": "1.117.0",
+        "@aws-cdk/aws-s3": "1.117.0",
+        "@aws-cdk/aws-ssm": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "@aws-cdk/cx-api": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "@aws-cdk/aws-cloudwatch": {
       "version": "1.117.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.117.0.tgz",
       "integrity": "sha512-nlG2D70rK9FZVBYXVPuD28S+ji6fjv/oNQn3YWX+GXl1uHbrVgb/YmcX7pidcK5rJReNOtjHnDewYY6fN5YDuA==",
       "requires": {
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-codebuild": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-1.117.0.tgz",
+      "integrity": "sha512-W0NXOPl/5+xhyyfZVIwWelE2F7hptTkPHYDfD62kwDSa3OVCARN+briHIVU9vJf3jtlyISZw06mzcL3jzTE3JQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.117.0",
+        "@aws-cdk/aws-codecommit": "1.117.0",
+        "@aws-cdk/aws-codestarnotifications": "1.117.0",
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-ecr": "1.117.0",
+        "@aws-cdk/aws-ecr-assets": "1.117.0",
+        "@aws-cdk/aws-events": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-logs": "1.117.0",
+        "@aws-cdk/aws-s3": "1.117.0",
+        "@aws-cdk/aws-s3-assets": "1.117.0",
+        "@aws-cdk/aws-secretsmanager": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "@aws-cdk/region-info": "1.117.0",
+        "constructs": "^3.3.69",
+        "yaml": "1.10.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.10.2",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/aws-codecommit": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-1.117.0.tgz",
+      "integrity": "sha512-XreEqld1YnsdHe9MtYqunaulPaZSEyaC6o1zyjTZUohi7EY6iuL4w693K1J9H0BnD5s6b9vpXqFUeM9wprFNBg==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.117.0",
         "@aws-cdk/aws-iam": "1.117.0",
         "@aws-cdk/core": "1.117.0",
         "constructs": "^3.3.69"
@@ -111,6 +202,20 @@
       "integrity": "sha512-ahyOT8KiGo1ufuI0xuPx/kLSnig1Kl60br5PcZK/0F/UvuZUh5yLLJS5DvvmLA2odizCkMztpCN/ts6+Iq2m7g==",
       "requires": {
         "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-codepipeline": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.117.0.tgz",
+      "integrity": "sha512-wqAK8tPgTILCDcH3jOKVF1Mq+pTF39H8/msX54pVGObpDNYN6OWgO6szCSB+OZrZMIQ75WlXfHEPOYHoEcSPlQ==",
+      "requires": {
+        "@aws-cdk/aws-codestarnotifications": "1.117.0",
+        "@aws-cdk/aws-events": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-s3": "1.117.0",
         "@aws-cdk/core": "1.117.0",
         "constructs": "^3.3.69"
       }
@@ -188,6 +293,18 @@
         "@aws-cdk/aws-iam": "1.117.0",
         "@aws-cdk/core": "1.117.0",
         "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-events": {
+          "version": "1.117.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.117.0.tgz",
+          "integrity": "sha512-VFHp0D2A/gMrkQSZieXfXWwGn3GJa3+53EiuDN8OOPQCPkFcsiwzKekeWjzbILX2m4Djqtjz041FzFicOJ95Fw==",
+          "requires": {
+            "@aws-cdk/aws-iam": "1.117.0",
+            "@aws-cdk/core": "1.117.0",
+            "constructs": "^3.3.69"
+          }
+        }
       }
     },
     "@aws-cdk/aws-ecr-assets": {
@@ -230,6 +347,39 @@
         }
       }
     },
+    "@aws-cdk/aws-ecs": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-1.117.0.tgz",
+      "integrity": "sha512-ssNkE5XI9W9oAgIhMeUDLr/zziO68pY9DZNoKW4Ma0P23BYP3NxJw2cAp2tROPE4QAXQDZRS5fHnUs4LFPK7NQ==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.117.0",
+        "@aws-cdk/aws-autoscaling": "1.117.0",
+        "@aws-cdk/aws-autoscaling-hooktargets": "1.117.0",
+        "@aws-cdk/aws-certificatemanager": "1.117.0",
+        "@aws-cdk/aws-cloudwatch": "1.117.0",
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-ecr": "1.117.0",
+        "@aws-cdk/aws-ecr-assets": "1.117.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.117.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-lambda": "1.117.0",
+        "@aws-cdk/aws-logs": "1.117.0",
+        "@aws-cdk/aws-route53": "1.117.0",
+        "@aws-cdk/aws-route53-targets": "1.117.0",
+        "@aws-cdk/aws-s3": "1.117.0",
+        "@aws-cdk/aws-s3-assets": "1.117.0",
+        "@aws-cdk/aws-secretsmanager": "1.117.0",
+        "@aws-cdk/aws-servicediscovery": "1.117.0",
+        "@aws-cdk/aws-sns": "1.117.0",
+        "@aws-cdk/aws-sqs": "1.117.0",
+        "@aws-cdk/aws-ssm": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "@aws-cdk/cx-api": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "@aws-cdk/aws-efs": {
       "version": "1.117.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.117.0.tgz",
@@ -241,6 +391,16 @@
         "@aws-cdk/cloud-assembly-schema": "1.117.0",
         "@aws-cdk/core": "1.117.0",
         "@aws-cdk/cx-api": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancing": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.117.0.tgz",
+      "integrity": "sha512-sQYYm3cYaU3whhLSmPqhMjZvIUJUYs4S7JFUAfo95roL99srXER2DytCPnAyOxqwlpLWn3CE2x5xAhXDOOeaoA==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
         "constructs": "^3.3.69"
       }
     },
@@ -272,6 +432,43 @@
         "constructs": "^3.3.69"
       }
     },
+    "@aws-cdk/aws-events-targets": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-1.117.0.tgz",
+      "integrity": "sha512-e2Gmn1wF6Chc1Yx0Gdsqz8luoIq7ieDYS+mvKboWa7FktjIfV9NQMerN2HGQhEQfU+KGnKBq+YxJB9XvKCEzUg==",
+      "requires": {
+        "@aws-cdk/aws-apigateway": "1.117.0",
+        "@aws-cdk/aws-codebuild": "1.117.0",
+        "@aws-cdk/aws-codepipeline": "1.117.0",
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-ecs": "1.117.0",
+        "@aws-cdk/aws-events": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kinesis": "1.117.0",
+        "@aws-cdk/aws-kinesisfirehose": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-lambda": "1.117.0",
+        "@aws-cdk/aws-logs": "1.117.0",
+        "@aws-cdk/aws-sns": "1.117.0",
+        "@aws-cdk/aws-sns-subscriptions": "1.117.0",
+        "@aws-cdk/aws-sqs": "1.117.0",
+        "@aws-cdk/aws-stepfunctions": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "@aws-cdk/custom-resources": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-globalaccelerator": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.117.0.tgz",
+      "integrity": "sha512-lLL9YMDxYN2M9ZaqGmgecFbv70jshOjLfV8JRm89nZ0fm0wyZ6wfLCM1a5Ql1ZxaxCwoBiVbH9JG0mJWSx996Q==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "@aws-cdk/custom-resources": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "@aws-cdk/aws-iam": {
       "version": "1.117.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.117.0.tgz",
@@ -292,6 +489,24 @@
         "@aws-cdk/aws-kms": "1.117.0",
         "@aws-cdk/aws-logs": "1.117.0",
         "@aws-cdk/core": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-kinesisfirehose": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.117.0.tgz",
+      "integrity": "sha512-68JUiEYxY46syYdzr3Bg8Y8PLaiSjPtODwjr81wk2v5Cg2MPKz1tmIRTuULySsChNbA6a3wBJEAqHeHrd9WPYw==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.117.0",
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kinesis": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-lambda": "1.117.0",
+        "@aws-cdk/aws-logs": "1.117.0",
+        "@aws-cdk/aws-s3": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "@aws-cdk/region-info": "1.117.0",
         "constructs": "^3.3.69"
       }
     },
@@ -330,6 +545,18 @@
         "@aws-cdk/cx-api": "1.117.0",
         "@aws-cdk/region-info": "1.117.0",
         "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-events": {
+          "version": "1.117.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.117.0.tgz",
+          "integrity": "sha512-VFHp0D2A/gMrkQSZieXfXWwGn3GJa3+53EiuDN8OOPQCPkFcsiwzKekeWjzbILX2m4Djqtjz041FzFicOJ95Fw==",
+          "requires": {
+            "@aws-cdk/aws-iam": "1.117.0",
+            "@aws-cdk/core": "1.117.0",
+            "constructs": "^3.3.69"
+          }
+        }
       }
     },
     "@aws-cdk/aws-logs": {
@@ -359,6 +586,26 @@
         "constructs": "^3.3.69"
       }
     },
+    "@aws-cdk/aws-route53-targets": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.117.0.tgz",
+      "integrity": "sha512-hINjs5zJgrHgaraFS6/AR7vpw229oUBeVC7xqKyBaBdZhFPt4K/SA9NNvoGPPEihmOQhzFId6b62ke6fOQDc/Q==",
+      "requires": {
+        "@aws-cdk/aws-apigateway": "1.117.0",
+        "@aws-cdk/aws-cloudfront": "1.117.0",
+        "@aws-cdk/aws-cognito": "1.117.0",
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.117.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.117.0",
+        "@aws-cdk/aws-globalaccelerator": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-route53": "1.117.0",
+        "@aws-cdk/aws-s3": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "@aws-cdk/region-info": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
     "@aws-cdk/aws-s3": {
       "version": "1.117.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.117.0.tgz",
@@ -370,6 +617,18 @@
         "@aws-cdk/core": "1.117.0",
         "@aws-cdk/cx-api": "1.117.0",
         "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-events": {
+          "version": "1.117.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.117.0.tgz",
+          "integrity": "sha512-VFHp0D2A/gMrkQSZieXfXWwGn3GJa3+53EiuDN8OOPQCPkFcsiwzKekeWjzbILX2m4Djqtjz041FzFicOJ95Fw==",
+          "requires": {
+            "@aws-cdk/aws-iam": "1.117.0",
+            "@aws-cdk/core": "1.117.0",
+            "constructs": "^3.3.69"
+          }
+        }
       }
     },
     "@aws-cdk/aws-s3-assets": {
@@ -383,6 +642,42 @@
         "@aws-cdk/aws-s3": "1.117.0",
         "@aws-cdk/core": "1.117.0",
         "@aws-cdk/cx-api": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-sam": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.117.0.tgz",
+      "integrity": "sha512-wUpKcZB81Q+Ub2n8JcOkOSbE1hYZ9f3us+QWYWCRJGu7t56rv6hhTyFRoeMYQMtLq3hkj0eAMqTYHaF82o0aWw==",
+      "requires": {
+        "@aws-cdk/core": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-secretsmanager": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.117.0.tgz",
+      "integrity": "sha512-1H/LFGfFrC4vjoJd9Fzob23AZxgMDxMiaH3tRVM4BRp13VH2gXGVVPixcweSZfnq29Mhz4Onu4F7FwAV7arQYg==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-lambda": "1.117.0",
+        "@aws-cdk/aws-sam": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "@aws-cdk/cx-api": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-servicediscovery": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.117.0.tgz",
+      "integrity": "sha512-wDL3tYWSBqLqhFjbthFIBrQW8UlWyTfJfsXui8s0/1Hw7HJLVp0vuUaPiDapXZVKstuOFCRE9a65NKwlToX+vA==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.117.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.117.0",
+        "@aws-cdk/aws-route53": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
         "constructs": "^3.3.69"
       }
     },
@@ -408,6 +703,32 @@
         "@aws-cdk/aws-sqs": "1.117.0",
         "@aws-cdk/core": "1.117.0",
         "constructs": "^3.3.69"
+      },
+      "dependencies": {
+        "@aws-cdk/aws-events": {
+          "version": "1.117.0",
+          "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.117.0.tgz",
+          "integrity": "sha512-VFHp0D2A/gMrkQSZieXfXWwGn3GJa3+53EiuDN8OOPQCPkFcsiwzKekeWjzbILX2m4Djqtjz041FzFicOJ95Fw==",
+          "requires": {
+            "@aws-cdk/aws-iam": "1.117.0",
+            "@aws-cdk/core": "1.117.0",
+            "constructs": "^3.3.69"
+          }
+        }
+      }
+    },
+    "@aws-cdk/aws-sns-subscriptions": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.117.0.tgz",
+      "integrity": "sha512-kkDxj6hqx3x18W254tqWGcqKqUXPYHdYP2lyjWf+Join6UzHuCoR/ZOBW09+EgxqKD3fWYWeJgCCJxSQn1esNQ==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-kms": "1.117.0",
+        "@aws-cdk/aws-lambda": "1.117.0",
+        "@aws-cdk/aws-sns": "1.117.0",
+        "@aws-cdk/aws-sqs": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "constructs": "^3.3.69"
       }
     },
     "@aws-cdk/aws-sqs": {
@@ -430,6 +751,20 @@
         "@aws-cdk/aws-iam": "1.117.0",
         "@aws-cdk/aws-kms": "1.117.0",
         "@aws-cdk/cloud-assembly-schema": "1.117.0",
+        "@aws-cdk/core": "1.117.0",
+        "constructs": "^3.3.69"
+      }
+    },
+    "@aws-cdk/aws-stepfunctions": {
+      "version": "1.117.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.117.0.tgz",
+      "integrity": "sha512-rDNbjRxjlFK8lHx+Y+Okcw/v8CXUZJ3xeTIhOwMYKgA4pVkgLk7nUcTMRh/+Eic9JjjSUgD9M5M3+x03jRZh+w==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.117.0",
+        "@aws-cdk/aws-events": "1.117.0",
+        "@aws-cdk/aws-iam": "1.117.0",
+        "@aws-cdk/aws-logs": "1.117.0",
+        "@aws-cdk/aws-s3": "1.117.0",
         "@aws-cdk/core": "1.117.0",
         "constructs": "^3.3.69"
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "dependencies": {
     "@aws-cdk/aws-apigateway": "1.117.0",
     "@aws-cdk/aws-dynamodb": "1.117.0",
+    "@aws-cdk/aws-events": "1.117.0",
+    "@aws-cdk/aws-events-targets": "1.117.0",
     "@aws-cdk/aws-lambda": "1.117.0",
     "@aws-cdk/aws-s3": "1.117.0",
     "@aws-cdk/core": "1.117.0"


### PR DESCRIPTION
Closes #9 

Adds a lambda function which pulls ticker prices for all tickers (currently using CoinGecko since only crypto tickers are implemented). Uses AWS EventBridge to schedule the cron invocation.