### PR TITLE
BUG: same dates for ticker prices and return tickers in get-portfolio

### DIFF
--- a/lambdas/create-ticker-prices-cron/app.js
+++ b/lambdas/create-ticker-prices-cron/app.js
@@ -36,6 +36,7 @@ exports.handler = async (event, context) => {
         const response = await axios.get(coinGeckoEndpoint);
         const data = response.data;
         let tickerIdToCoin = {};
+        const dateStr = new Date().toISOString();
         await Promise.all(tickers.Items.map(async (t) => {
             params = {
                 TableName: TickerPriceTableName,
@@ -47,7 +48,7 @@ exports.handler = async (event, context) => {
                         S: t['id']['S']
                     },
                     'datetime': {
-                        S: new Date().toISOString()
+                        S: dateStr
                     },
                     'price': {
                         N: `${data[t['coinId']['S']]['gbp']}`

--- a/lambdas/get-portfolio-full/app.js
+++ b/lambdas/get-portfolio-full/app.js
@@ -3,6 +3,7 @@ const AWS = require('aws-sdk');
 
 const HoldingsTableName = process.env.HOLDINGS_TABLE_NAME;
 const TransactionsTableName = process.env.TRANSACTIONS_TABLE_NAME;
+const TickersTableName = process.env.TICKERS_TABLE_NAME;
 const TickerPricesTableName = process.env.TICKER_PRICES_TABLE_NAME;
 
 
@@ -32,20 +33,28 @@ exports.handler = async (event, context) => {
             TableName: HoldingsTableName
         };
         const holdings = await dbClient.scan(params).promise();
+
         params = {
             TableName: TransactionsTableName
         };
         const transactions = await dbClient.scan(params).promise();
+
         params = {
             TableName: TickerPricesTableName
         };
         const tickerPrices = await dbClient.scan(params).promise();
+
+        params = {
+            TableName: TickersTableName
+        };
+        const tickers = await dbClient.scan(params).promise();
 
         response.statusCode = 200;
         response.body = JSON.stringify({
             holdings: holdings,
             transactions: transactions,
             tickerPrices: tickerPrices,
+            tickers: tickers,
         })
         console.log(response)
     } catch (err) {

--- a/lib/finance-dash-server-stack.ts
+++ b/lib/finance-dash-server-stack.ts
@@ -200,6 +200,7 @@ export class FinanceDashServerStack extends Stack {
                 'HOLDINGS_TABLE_NAME': holdingsTable.tableName,
                 'TRANSACTIONS_TABLE_NAME': transactionTable.tableName,
                 'TICKER_PRICES_TABLE_NAME': tickerPriceTable.tableName,
+                'TICKERS_TABLE_NAME': tickerTable.tableName,
             }
         });
 
@@ -208,6 +209,7 @@ export class FinanceDashServerStack extends Stack {
         tickerTable.grantReadData(listTickersFunction);
         tickerTable.grantReadData(createTickerPricesCronFunction);
         tickerTable.grantReadData(getHoldingFunction);
+        tickerTable.grantReadData(getPortfolioFullFunction);
         
         tickerPriceTable.grantWriteData(createTickerPriceFunction);
         tickerPriceTable.grantWriteData(createTickerPricesCronFunction);
@@ -221,7 +223,7 @@ export class FinanceDashServerStack extends Stack {
         holdingsTable.grantReadData(listHoldingsFunction);
         holdingsTable.grantReadData(getHoldingFunction);
         holdingsTable.grantReadData(getPortfolioFullFunction);
-        
+
         transactionTable.grantWriteData(createTransactionFunction);
         transactionTable.grantReadData(getHoldingFunction);
         transactionTable.grantReadData(getPortfolioFullFunction);


### PR DESCRIPTION
Gave all ticker prices for a single cron job the same datetime to ease visualisation. Added tickers in the response for get-portfolio-full lambda.