### PR TITLE
ENH: pull coin market history

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,19 @@ Backend lambdas and CDK stack for portfolio tracking web app. Repository for app
 ### Development
 
 Start localstack services with docker-compose:
+
 `docker-compose up`
 
 Bootstrap localstack environment:
+
 `cdklocal bootstrap`
 
 Deply CDK stack locally:
+
 `cdklocal deploy`
 
 To use dynamodb-admin web interface:
+
 `DYNAMO_ENDPOINT=http://localhost:4566 dynamodb-admin`
 
 ### AWS Deployment

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Backend lambdas and CDK stack for portfolio tracking web app. Repository for app
 ### Development
 
 Start localstack services with docker-compose:
-
 `docker-compose up`
 
 Bootstrap localstack environment:
-
 `cdklocal bootstrap`
 
 Deply CDK stack locally:
-
 `cdklocal deploy`
+
+To use dynamodb-admin web interface:
+`DYNAMO_ENDPOINT=http://localhost:4566 dynamodb-admin`
 
 ### AWS Deployment
 

--- a/lambdas/create-holding/app.js
+++ b/lambdas/create-holding/app.js
@@ -1,9 +1,11 @@
 const AWS = require('aws-sdk');
+const axios = require('axios');
 const { v4: uuidv4 } = require('uuid');
 const CoinGecko = require('coingecko-api');
 const lodash = require('lodash');
 const TickersTableName = process.env.TICKERS_TABLE_NAME;
 const HoldingsTableName = process.env.HOLDINGS_TABLE_NAME;
+const TickerPricesTableName = process.env.TICKER_PRICES_TABLE_NAME;
 
 // TODO: move to utils / shared location
 let dynamoDbClient;
@@ -20,6 +22,16 @@ const makeClient = () => {
 const dbClient = makeClient()
 
 const CoinGeckoClient = new CoinGecko();
+
+// since ddb can only take 25 items at a time, split into chunks
+const splitItemsChunks = (arr, chunkSize=25) => {
+    const res = [];
+    for (let i = 0; i < arr.length; i += chunkSize) {
+        const chunk = arr.slice(i, i + chunkSize);
+        res.push(chunk);
+    }
+    return res;
+}
 
 let response;
 exports.handler = async (event, context) => {
@@ -106,6 +118,77 @@ exports.handler = async (event, context) => {
         }
 
         await dbClient.putItem(params).promise();
+        
+        const coinGeckoHistoricalDataEndpoint = (
+            `https://api.coingecko.com/api/v3/coins/${pickedCryptoId}/market_chart`
+            + '?vs_currency=gbp'
+            + '&days=20'
+            + '&interval=daily'
+        );
+        const historyResponse = await axios.get(coinGeckoHistoricalDataEndpoint);
+        
+        const putRequests = historyResponse.data.prices.map(([datetime, price]) => {
+            return {
+                PutRequest: {
+                    Item: {
+                        'id': {
+                            S: uuidv4()
+                        },
+                        'tickerId': {
+                            S: tickerId
+                        },
+                        'datetime': {
+                            S: new Date(datetime).toISOString()
+                        },
+                        'price': {
+                            N: `${price}`
+                        },
+                        'twentyFourHourChange': {
+                            N: '0'
+                        }
+                    }
+                }
+            }
+        });
+
+        console.log(tickerId);
+
+        const chunks = splitItemsChunks(putRequests);
+        // this should be a map but couldn't get working with async
+        for (let i = 0; i < chunks.length; i += 1) {
+            params = {
+                RequestItems: {
+                    [TickerPricesTableName]: chunks[i]
+                }
+            };
+            await dbClient.batchWriteItem(params).promise();
+        }
+
+
+        // splitItemsChunks(putRequests).map(async function(chunk) {
+        //     params = {
+        //         RequestItems: {
+        //             [TickerPricesTableName]: chunk
+        //         }
+        //     };
+        //     // console.log(JSON.stringify(params));
+        //     try {
+        //         console.log("here123")
+        //         const rap = await dbClient.batchWriteItem(params).promise();
+        //         console.log("reached123")
+        //         console.log(rap);
+        //     } catch (err) {
+        //         console.log("ERROR")
+        //     }
+            
+        //     // await dbClient.batchWriteItem(params).promise()
+        //     //     .then((data) => {
+        //     //         console.log("success", data);
+        //     //     })
+        //     //     .catch((err) => {
+        //     //         console.log(err);
+        //     //     })
+        // }).promise();
 
         response = {
             statusCode: 200,

--- a/lambdas/create-holding/app.js
+++ b/lambdas/create-holding/app.js
@@ -153,8 +153,6 @@ exports.handler = async (event, context) => {
             }
         });
 
-        console.log(tickerId);
-
         const chunks = splitItemsChunks(putRequests);
         // this should be a map but couldn't get working with async
         for (let i = 0; i < chunks.length; i += 1) {

--- a/lambdas/create-holding/package-lock.json
+++ b/lambdas/create-holding/package-lock.json
@@ -27,6 +27,14 @@
                 }
             }
         },
+        "axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "requires": {
+                "follow-redirects": "^1.14.0"
+            }
+        },
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -51,6 +59,11 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "follow-redirects": {
+            "version": "1.14.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
         },
         "ieee754": {
             "version": "1.1.13",

--- a/lambdas/create-holding/package.json
+++ b/lambdas/create-holding/package.json
@@ -9,6 +9,7 @@
     "author": "Robbie Dunn",
     "dependencies": {
         "aws-sdk": "*",
+        "axios": "^0.21.1",
         "coingecko-api": "^1.0.10",
         "lodash": "^4.17.21",
         "uuid": "*"

--- a/lambdas/get-holding/app.js
+++ b/lambdas/get-holding/app.js
@@ -31,8 +31,6 @@ exports.handler = async (event, context) => {
         };
         const holdingGetData = await dbClient.getItem(params).promise();
 
-        console.log(holdingGetData);
-
         params = {
             TableName: TickersTableName,
             Key: {

--- a/lambdas/get-holding/app.js
+++ b/lambdas/get-holding/app.js
@@ -31,6 +31,8 @@ exports.handler = async (event, context) => {
         };
         const holdingGetData = await dbClient.getItem(params).promise();
 
+        console.log(holdingGetData);
+
         params = {
             TableName: TickersTableName,
             Key: {

--- a/lib/finance-dash-server-stack.ts
+++ b/lib/finance-dash-server-stack.ts
@@ -155,6 +155,7 @@ export class FinanceDashServerStack extends Stack {
             environment: {
                 'TICKERS_TABLE_NAME': tickerTable.tableName,
                 'HOLDINGS_TABLE_NAME': holdingsTable.tableName,
+                'TICKER_PRICES_TABLE_NAME': tickerPriceTable.tableName,
             }
         });
 
@@ -213,6 +214,7 @@ export class FinanceDashServerStack extends Stack {
         
         tickerPriceTable.grantWriteData(createTickerPriceFunction);
         tickerPriceTable.grantWriteData(createTickerPricesCronFunction);
+        tickerPriceTable.grantWriteData(createHoldingFunction);
         tickerPriceTable.grantReadData(getTickerPricesByTickerIdFunction)
         tickerPriceTable.grantReadData(getHoldingFunction);
         tickerPriceTable.grantReadData(getPortfolioFullFunction);


### PR DESCRIPTION
Updated creation of holding to also pull the maximum amount of historical daily data. Bulk inserts these to dynamodb (had to split into chunks since there is a limit of 25 per bulk request).

Also added instructions in readme for using dynamodb-admin web interface (useful for debugging during local testing).