### PR TITLE
ENH: extend ticker price model and UI improvements

### DIFF
--- a/cdk_back/lambdas/create-holding/app.js
+++ b/cdk_back/lambdas/create-holding/app.js
@@ -119,10 +119,10 @@ exports.handler = async (event, context) => {
                 tickerId,                                           // ticker_id
                 new Date(histDate).toISOString(),                   // datetime
                 `${curr[1]}`,                                       // price
-                'NULL',                                             // twenty_four_hour_change
+                'null',                                             // twenty_four_hour_change
                 `${historicalRes.data.market_caps[index][1]}`,      // market cap
                 `${historicalRes.data.total_volumes[index][1]}`,    // volume
-                'NULL',                                             // last_updated 
+                'null',                                             // last_updated 
             ]
         });
 
@@ -135,7 +135,7 @@ exports.handler = async (event, context) => {
         console.log("Connecting to PG pool");
         const poolClient = await pool.connect();
         console.log("Connected to PG pool");
-        const stream = poolClient.query(copyFrom('COPY ticker_prices FROM STDIN WITH NULL as \'NULL\''));
+        const stream = poolClient.query(copyFrom('COPY ticker_prices FROM STDIN WITH NULL as \'null\''));
         const fileStream = fs.createReadStream('/tmp/bulk.tsv');
         fileStream.pipe(stream);
 

--- a/cdk_back/lambdas/create-ticker-prices-cron/app.js
+++ b/cdk_back/lambdas/create-ticker-prices-cron/app.js
@@ -38,13 +38,19 @@ exports.handler = async (event, context) => {
                     ticker_id,
                     datetime,
                     price,
-                    twenty_four_hour_change
+                    twenty_four_hour_change,
+                    market_cap,
+                    volume,
+                    last_updated
                 ) VALUES (
                     '${uuidv4()}',
                     '${t['ticker_id']}',
                     '${dateStr}',
                     '${data[t['coin_id']]['gbp']}',
-                    '${data[t['coin_id']]['gbp_24h_change']}'
+                    '${data[t['coin_id']]['gbp_24h_change']}',
+                    '${data[t['coin_id']]['gbp_market_cap']}',
+                    '${data[t['coin_id']]['gbp_24h_vol']}',
+                    '${new Date(data[t['coin_id']]['last_updated_at']).toISOString()}'
                 )
             `;
             // console.log(`Insert ticker price query ${insertTickerPriceQuery}`);

--- a/cdk_back/lambdas/create-ticker-prices-cron/app.js
+++ b/cdk_back/lambdas/create-ticker-prices-cron/app.js
@@ -50,7 +50,7 @@ exports.handler = async (event, context) => {
                     '${data[t['coin_id']]['gbp_24h_change']}',
                     '${data[t['coin_id']]['gbp_market_cap']}',
                     '${data[t['coin_id']]['gbp_24h_vol']}',
-                    '${new Date(data[t['coin_id']]['last_updated_at']).toISOString()}'
+                    '${dateStr}'
                 )
             `;
             // console.log(`Insert ticker price query ${insertTickerPriceQuery}`);

--- a/cdk_back/lambdas/create-ticker-prices-cron/app.js
+++ b/cdk_back/lambdas/create-ticker-prices-cron/app.js
@@ -29,7 +29,6 @@ exports.handler = async (event, context) => {
         const data = response.data;
 
         // Insert new ticker price for each scanned ticker
-        let tickerIdToCoin = {};
         const dateStr = new Date().toISOString();
         await Promise.all(scanTickersRes.rows.map(async (t) => {
             const insertTickerPriceQuery = `
@@ -56,13 +55,6 @@ exports.handler = async (event, context) => {
             // console.log(`Insert ticker price query ${insertTickerPriceQuery}`);
             await client.query(insertTickerPriceQuery);
             // console.log(insertTickerPriceRes);
-
-            tickerIdToCoin[t['ticker_id']] = {
-                price: data[t['coin_id']]['gbp'],
-                change: data[t['coin_id']]['gbp_24h_change'],
-                marketCap: data[t['coin_id']]['gbp_market_cap'],
-                volume: data[t['coin_id']]['gbp_24h_vol']
-            };
         }));
         await client.end();
     } catch (err) {

--- a/cdk_back/lambdas/get-holding/app.js
+++ b/cdk_back/lambdas/get-holding/app.js
@@ -35,7 +35,7 @@ exports.handler = async (event, context) => {
         // Get ticker prices for the associated ticker id
         const holdingTickerId = getHoldingResp.rows[0].ticker_id;
         const getTickerPricesForHoldingQuery = `
-            SELECT * FROM ticker_prices WHERE ticker_id='${holdingTickerId}'
+            SELECT * FROM ticker_prices WHERE ticker_id='${holdingTickerId} ORDER BY datetime DESC'
         `;
         const getTickerPricesForHoldingRes = await client.query(getTickerPricesForHoldingQuery);
         console.log(getTickerPricesForHoldingRes);

--- a/cdk_back/lambdas/init-db/app.js
+++ b/cdk_back/lambdas/init-db/app.js
@@ -140,7 +140,7 @@ exports.handler = async(event, context) => {
                         tickers.image_url AS image_url,
                         tickers.coin_id AS coin_id,
                         tickers.ticker_id AS ticker_id,
-                        holdings.color AS colorw
+                        holdings.color AS color
                     FROM holdings 
                         INNER JOIN tickers ON holdings.ticker_id=tickers.ticker_id
             `;

--- a/cdk_back/lambdas/init-db/app.js
+++ b/cdk_back/lambdas/init-db/app.js
@@ -109,6 +109,9 @@ exports.handler = async(event, context) => {
                     datetime                    timestamp,
                     price                       numeric,
                     twenty_four_hour_change     numeric,
+                    market_cap                  numeric,
+                    volume                      numeric,
+                    last_updated                timestamp,
                     CONSTRAINT fk_ticker
                         FOREIGN KEY(ticker_id)
                             REFERENCES tickers(ticker_id)

--- a/cdk_back/lambdas/init-db/app.js
+++ b/cdk_back/lambdas/init-db/app.js
@@ -146,8 +146,40 @@ exports.handler = async(event, context) => {
             `;
             const createGetHoldingViewRes = await client.query(createGetHoldingViewQuery);
             console.log(createGetHoldingViewRes);
+        } catch (err) {
+            console.log(err);
         }
-        catch (err) {
+
+        // List holdings view
+        try {
+            const createListHoldingsViewQuery = `
+                CREATE OR REPLACE VIEW list_holdings_view AS
+                    SELECT DISTINCT ON (h)
+                        h.holding_id AS holding_id,
+                        h.units AS units,
+                        t.ticker_name AS ticker_name,
+                        t.symbol AS ticker_symbol,
+                        t.image_url AS ticker_logo,
+                        p.price AS ticker_price,
+                        p.twenty_four_hour_change AS ticker_twenty_four_change,
+                        p.last_updated AS ticker_last_updated,
+                        p.price * h.units AS market_value,
+                        p.twenty_four_hour_change * h.units AS holding_twenty_four_hour_change
+                    FROM holdings h
+                        JOIN tickers t on h.ticker_id = t.ticker_id
+                        JOIN (
+                            SELECT
+                                C.*,
+                                row_number() OVER (
+                                    PARTITION BY C.ticker_id
+                                    ORDER BY C.datetime DESC
+                                ) AS rn
+                            FROM ticker_prices C
+                        ) p ON p.ticker_id = t.ticker_id and p.rn = 1
+            `;
+            const createListHoldingsViewRes = await client.query(createListHoldingsViewQuery);
+            console.log(createListHoldingsViewRes);
+        } catch (err) {
             console.log(err);
         }
 

--- a/cdk_back/lambdas/list-holdings/app.js
+++ b/cdk_back/lambdas/list-holdings/app.js
@@ -13,7 +13,7 @@ exports.handler = async (event, context) => {
         await client.connect();
         console.log("Connected to postgres")
 
-        const listHoldingsQuery = 'SELECT * FROM get_holding_view';
+        const listHoldingsQuery = 'SELECT * FROM list_holdings_view';
         console.log(`List holdings query: ${listHoldingsQuery}`);
         const listHoldingsResp = await client.query(listHoldingsQuery);
         console.log(listHoldingsResp);
@@ -22,9 +22,12 @@ exports.handler = async (event, context) => {
 
         response.statusCode = 200;
         response.body = JSON.stringify({
-            items: listHoldingsResp.rows.map(
-                obj => ({ ...obj, market_value: `${obj.units * obj.current_price}` })
-            )
+            items: listHoldingsResp.rows.map((h) => {
+                return {
+                     ...h,
+                     holding_twenty_four_hour_change: (h.ticker_twenty_four_hour_change / 100) * h.ticker_price
+                }
+            })
         });
     } catch (err) {
         console.log(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "finance-dash-server",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "finance-dash-server",
-    "version": "0.9.1",
+    "version": "0.10.0",
     "private": true,
     "dependencies": {
         "@emotion/react": "^11.7.1",

--- a/src/components/ClippedDrawer.js
+++ b/src/components/ClippedDrawer.js
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
   },
   appBar: {
     zIndex: theme.zIndex.drawer + 1,
-    // backgroundColor: '#0b3910'
+    background: 'linear-gradient(0deg, rgba(41,3,48,1) 0%, rgba(116,15,135,1) 100%)'
   },
   drawer: {
     width: drawerWidth,
@@ -46,7 +46,8 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(3),
   },
   navItemSelected: {
-    backgroundColor: theme.palette.secondary.main,
+    // backgroundColor: theme.palette.secondary.main,
+    background: 'linear-gradient(0deg, rgba(74,57,13,1) 0%, rgba(163,128,32,1) 100%)'
   },
   nested: {
     paddingLeft: theme.spacing(4),
@@ -79,7 +80,7 @@ export default function ClippedDrawer() {
             >
                 <Toolbar />
                 <div className={classes.drawerContainer}>
-                    <List>
+                    <List disablePadding>
                         <ListItem 
                             button 
                             key='Dashboard' 

--- a/src/components/HoldingPriceChart/AreaChart.js
+++ b/src/components/HoldingPriceChart/AreaChart.js
@@ -38,7 +38,6 @@ export default function AreaChart({
     chartColor,
 }) {
 
-    console.log(chartColor);
     const {
         tooltipData,
         tooltipLeft,

--- a/src/components/HoldingPriceChart/AreaChart.js
+++ b/src/components/HoldingPriceChart/AreaChart.js
@@ -38,6 +38,7 @@ export default function AreaChart({
     chartColor,
 }) {
 
+    console.log(chartColor);
     const {
         tooltipData,
         tooltipLeft,

--- a/src/components/HoldingView.js
+++ b/src/components/HoldingView.js
@@ -116,6 +116,7 @@ export default function HoldingView() {
                 return [new Date(p.datetime), parseFloat(p.price)]
             }));
             setTransactions(res.data.transactions);
+            console.log(`Setting holding color to ${res.data.holding.color}`)
             setHoldingColor(res.data.holding.color);
         });
     }, [holdingId]);

--- a/src/components/HoldingView.js
+++ b/src/components/HoldingView.js
@@ -87,7 +87,7 @@ export default function HoldingView() {
 
     const [name, setName] = useState('');
     const [symbol, setSymbol] = useState('');
-    // const [units, setUnits] = useState(0);
+    const [units, setUnits] = useState(0);
     const [currentPrice, setCurrentPrice] = useState(0);
     // const [tickerId, setTickerId] = useState('');
     const [imageUrl, setImageUrl] = useState('');
@@ -105,19 +105,26 @@ export default function HoldingView() {
             console.log(res);
             setName(res.data.holding.ticker_name);
             setSymbol(res.data.holding.ticker_symbol);
-            // setUnits(res.data.holding.units);
-            setCurrentPrice(res.data.holding.current_price);
+            setUnits(res.data.holding.units);
+            // setCurrentPrice(res.data.holding.current_price);
             // setTickerId(res.data.holding.ticker_id);
             setImageUrl(res.data.holding.image_url);
-            setTwentyFourHrChange(res.data.holding.twenty_four_hour_change);
-            setTwentyFourHrVolume(res.data.holding.volume);
-            setMarketCap(res.data.holding.market_cap);
+            // setTwentyFourHrChange(res.data.holding.twenty_four_hour_change);
+            // setTwentyFourHrVolume(res.data.holding.volume);
+            // setMarketCap(res.data.holding.market_cap);
             setTickerPrices(res.data.tickerPrices.map((p) => {
                 return [new Date(p.datetime), parseFloat(p.price)]
             }));
             setTransactions(res.data.transactions);
             console.log(`Setting holding color to ${res.data.holding.color}`)
             setHoldingColor(res.data.holding.color);
+
+            const recentTP = res.data.tickerPrices[res.data.tickerPrices.length - 1];
+            console.log(recentTP);
+            setCurrentPrice(recentTP.price);
+            setTwentyFourHrChange(recentTP.twenty_four_hour_change);
+            setMarketCap(recentTP.market_cap);
+            setTwentyFourHrVolume(recentTP.volume);
         });
     }, [holdingId]);
 
@@ -179,11 +186,49 @@ export default function HoldingView() {
                         </div>
                     </div>
                     <Divider className={classes.divider}></Divider>
-                    <TransactionsTable transactions={transactions} currentPrice={currentPrice} holdingId={holdingId}></TransactionsTable>
+                    <div style={{ display: 'flex' }}>
+                        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+                            <div style={{ display: 'flex', flex: 1 }}>
+                                <div style={{ flex: 1 }} className={classes.coinPricesLabel}>
+                                    <Typography variant='h6'>Units</Typography>
+                                </div>
+                                <div style={{ flex: 1 }}>
+                                    <Typography variant='h6'>{units}</Typography>
+                                </div>
+                            </div>
+                            <div style={{ display: 'flex', flex: 1 }}>
+                                <div style={{ flex: 1 }} className={classes.coinPricesLabel}>
+                                    <Typography variant='h6'>Market value</Typography>
+                                </div>
+                                <div style={{ flex: 1 }}>
+                                    <Typography variant='h6'>
+                                        {toCurrencyString(units * currentPrice)}
+                                    </Typography>
+                                </div>
+                            </div>
+                        </div>
+                        <div style={{ flex: 1, display: 'flex' }}>
+                            <div style={{ flex: 1 }}>
+                                <Typography variant='body1'>Price</Typography>
+                            </div>
+                            <div style={{ flex: 1 }}>
+                                <Typography variant='body1'>{toCurrencyString(currentPrice)}</Typography>
+                            </div>
+                        </div>
+                    </div>
+                    <TransactionsTable 
+                        transactions={transactions}
+                        currentPrice={currentPrice}
+                        twentyFour={twentyFourHrChange}
+                        holdingId={holdingId}
+                    ></TransactionsTable>
+                    <HoldingPriceChart data={tickerPrices} chartColor={holdingColor} />
+                    
                 </div>
+                
             </div>            
             {/* <XYGraph graphData = {tickerPrices} /> */}
-            <HoldingPriceChart data={tickerPrices} chartColor={holdingColor} />
+            {/* <HoldingPriceChart data={tickerPrices} chartColor={holdingColor} /> */}
             {/* <HoldingPriceChart 
                 chartData={tickerPrices}
                 hideBottomAxis

--- a/src/components/HoldingsList/HoldingsTable.js
+++ b/src/components/HoldingsList/HoldingsTable.js
@@ -19,7 +19,7 @@ import Checkbox from '@mui/material/Checkbox';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { toCurrencyString } from '../../utils';
+import { toCurrencyString, toGainString } from '../../utils';
 import CreateHoldingDialog from './CreateHoldingDialog';
 
 
@@ -58,11 +58,14 @@ function stableSort(array, comparator) {
 
 
 const headCells = [
+    { id: 'logo', numeric: false, disablePadding: false, label: '', width: '25px' },
     { id: 'name', numeric: false, disablePadding: false, label: 'Name' },
-    { id: 'symbol', numeric: false, disablePadding: false, label: 'Symbol' },
-    { id: 'currentPrice', numeric: false, disablePadding: false, label: 'Current Price' },
     { id: 'units', numeric: false, disablePadding: false, label: 'Units' },
-    { id: 'marketValue', numeric: false, disablePadding: false, label: 'Market Value'}
+    { id: 'ticker_price', numeric: false, disablePadding: false, label: 'Price' },
+    { id: 'ticker_twenty_four_change', numeric: false, disablePadding: false, label: 'Price 24h' },
+    { id: 'market_value', numeric: false, disablePadding: false, label: 'Market value'},
+    { id: 'market_value_twenty_four_change', numeric: false, disablePadding: false, label: 'Gain 24h'},
+    { id: 'market_value_total_change', numeric: false, disablePadding: false, label: 'Gain total'},
 ];
 
 
@@ -89,6 +92,7 @@ function EnhancedTableHead(props) {
                     align={headCell.numeric ? 'right' : 'left'}
                     padding={headCell.disablePadding ? 'none' : 'normal'}
                     sortDirection={orderBy === headCell.id ? order : false}
+                    width={headCell.width ? headCell.width : null}
                 >
                     <TableSortLabel
                         active={orderBy === headCell.id}
@@ -201,6 +205,10 @@ const useStyles = makeStyles((theme) => ({
     position: 'absolute',
     top: 20,
     width: 1,
+  },
+  tickerLogo: {
+      height: 30,
+      verticalAlign: 'middle'
   }
 }));
 
@@ -214,16 +222,19 @@ export default function HoldingsTable(props) {
     const [page, setPage] = React.useState(0);
     const [rowsPerPage, setRowsPerPage] = React.useState(10);
 
-    const rows = props.holdings.map(holding => {
-        return createData(
-            holding['holding_id'],
-            holding['ticker_name'],
-            holding['ticker_symbol'],
-            holding['units'],
-            holding['current_price'],
-            holding['market_value'],
-        );
-    });
+    const rows = props.holdings;
+    // const rows = props.holdings.map(holding => {
+    //     console.log(holding)
+    //     return createData(
+    //         holding['holding_id'],
+    //         holding['units'],
+    //         holding['ticker_name'],
+    //         holding['ticker_symbol'],
+    //         holding['units'],
+    //         holding['ticker_price'],
+    //         holding['market_value'],
+    //     );
+    // });
 
     const handleRequestSort = (event, property) => {
         const isAsc = orderBy === property && order === 'asc';
@@ -233,7 +244,7 @@ export default function HoldingsTable(props) {
 
     const handleSelectAllClick = (event) => {
         if (event.target.checked) {
-            const newSelecteds = rows.map((n) => n.id);
+            const newSelecteds = rows.map((n) => n.holding_id);
             setSelected(newSelecteds);
             return;
         }
@@ -299,7 +310,7 @@ export default function HoldingsTable(props) {
                             {stableSort(rows, getComparator(order, orderBy))
                                 .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                                 .map((row, index) => {
-                                    const isItemSelected = isSelected(row.id);
+                                    const isItemSelected = isSelected(row.holding_id);
                                     const labelId = `enhanced-table-checkbox-${index}`;
                                     // let totalGainClass;
                                     // if (row.totalGain < 0) {
@@ -313,25 +324,28 @@ export default function HoldingsTable(props) {
                                             role="checkbox"
                                             aria-checked={isItemSelected}
                                             tabIndex={-1}
-                                            key={row.id}
+                                            key={row.holding_id}
                                             selected={isItemSelected}
-                                            onDoubleClick={(event) => handleRowCLick(event, row.id)}
+                                            onDoubleClick={(event) => handleRowCLick(event, row.holding_id)}
                                             sx={{cursor: 'pointer'}}
                                         >
                                         <TableCell padding="checkbox">
                                             <Checkbox
-                                                onClick={(event) => handleClick(event, row.id)}
+                                                onClick={(event) => handleClick(event, row.holding_id)}
                                                 checked={isItemSelected}
                                                 inputProps={{ 'aria-labelledby': labelId }}
                                             />
                                         </TableCell>
                                         <TableCell component="th" id={labelId} scope="row">
-                                        {row.name}
+                                        <img src={row.ticker_logo} alt="Coin logo" className={classes.tickerLogo} ></img>
                                         </TableCell>
-                                        <TableCell>{row.symbol}</TableCell>
-                                        <TableCell>{toCurrencyString(row.currentPrice)}</TableCell>
+                                        <TableCell>{row.ticker_name} ({row.ticker_symbol})</TableCell>
                                         <TableCell>{row.units}</TableCell>
-                                        <TableCell>{toCurrencyString(row.marketValue)}</TableCell>
+                                        <TableCell>{toCurrencyString(row.ticker_price)}</TableCell>
+                                        <TableCell>{toGainString(row.ticker_twenty_four_change, row.ticker_price)}</TableCell>
+                                        <TableCell>{toCurrencyString(row.market_value)}</TableCell>
+                                        <TableCell>{toGainString(row.ticker_twenty_four_change, row.market_value)}</TableCell>
+                                        <TableCell>{toGainString(row.ticker_twenty_four_change, row.market_value)}</TableCell>
                                         </TableRow>
                                     );
                                 }

--- a/src/components/HoldingsList/HoldingsTable.js
+++ b/src/components/HoldingsList/HoldingsTable.js
@@ -352,7 +352,7 @@ export default function HoldingsTable(props) {
                             )}
                             {emptyRows > 0 && (
                                 <TableRow style={{ height: 53 * emptyRows }}>
-                                <TableCell colSpan={6} />
+                                <TableCell colSpan={9} />
                                 </TableRow>
                             )}
                         </TableBody>

--- a/src/components/TransactionsTable.js
+++ b/src/components/TransactionsTable.js
@@ -18,11 +18,11 @@ import Checkbox from '@mui/material/Checkbox';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { toCurrencyString } from '../utils';
+import { toCurrencyString, toGainString } from '../utils';
 import CreateTransactionDialog from './CreateTransactionDialog';
 
-function createData(id, datetime, buySell, units, price, totalGain) {
-    return { id, datetime, buySell, units, price, totalGain };
+function createData(id, datetime, buySell, units, price, currentPrice, twentyFour, totalGain) {
+    return { id, datetime, buySell, units, price, currentPrice, twentyFour, totalGain };
 }
 
 function descendingComparator(a, b, orderBy) {
@@ -55,8 +55,10 @@ const headCells = [
     { id: 'datetime', numeric: false, disablePadding: true, label: 'Datetime' },
     { id: 'buySell', numeric: true, disablePadding: false, label: 'Buy/sell' },
     { id: 'units', numeric: true, disablePadding: false, label: 'Units' },
-    { id: 'price', numeric: true, disablePadding: false, label: 'Price' },
-    { id: 'totalGain', numeric: true, disablePadding: false, label: 'Total gain (%)'}
+    { id: 'price', numeric: true, disablePadding: false, label: 'Purchase price' },
+    { id: 'currentPrice', numeric: true, disablePadding: false, label: 'Current price' },
+    { id: 'twentyFourGain', numeric: true, disablePadding: false, label: '24h gain' },
+    { id: 'totalGain', numeric: true, disablePadding: false, label: 'Total gain'}
 ];
 
 function EnhancedTableHead(props) {
@@ -191,12 +193,6 @@ const useStyles = makeStyles((theme) => ({
     top: 20,
     width: 1,
   },
-  gainLoss: {
-    color: '#f03333'
-  },
-  gainProfit: {
-      color: '#13cb13'
-  }
 }));
 
 export default function TransactionsTable(props) {
@@ -214,7 +210,9 @@ export default function TransactionsTable(props) {
             tx['buy_sell'], 
             tx['units'], 
             tx['price'],
-            (props.currentPrice * tx['units']) - tx['price']
+            (props.currentPrice * tx['units']),
+            (props.twentyFour),
+            (props.currentPrice * tx['units']) - tx['price'],
         )
     ));
 
@@ -290,12 +288,6 @@ export default function TransactionsTable(props) {
                                 .map((row, index) => {
                                     const isItemSelected = isSelected(row.id);
                                     const labelId = `enhanced-table-checkbox-${index}`;
-                                    let totalGainClass;
-                                    if (row.totalGain < 0) {
-                                        totalGainClass = classes.gainLoss
-                                    } else {
-                                        totalGainClass = classes.gainProfit
-                                    }
                                     return (
                                         <TableRow
                                         hover
@@ -318,14 +310,20 @@ export default function TransactionsTable(props) {
                                         <TableCell align="right">{row.buySell}</TableCell>
                                         <TableCell align="right">{row.units}</TableCell>
                                         <TableCell align="right">{toCurrencyString(row.price)}</TableCell>
-                                        <TableCell align="right" className={totalGainClass}>{`${toCurrencyString(row.totalGain)} (${(100 * row.totalGain / row.price).toFixed(2)}%)`}</TableCell>
+                                        <TableCell align="right">{toCurrencyString(row.currentPrice)}</TableCell>
+                                        <TableCell align="right">{toGainString(row.twentyFour, row.price)}</TableCell>
+                                        <TableCell align="right">{toGainString((100 * row.totalGain / row.price), row.price)}
+                                            
+                                            
+                                            {/* {`${toCurrencyString(row.totalGain)} (${(100 * row.totalGain / row.price).toFixed(2)}%)`} */}
+                                            </TableCell>
                                         </TableRow>
                                     );
                                 }
                             )}
                             {emptyRows > 0 && (
                                 <TableRow style={{ height: 53 * emptyRows }}>
-                                <TableCell colSpan={6} />
+                                <TableCell colSpan={8} />
                                 </TableRow>
                             )}
                         </TableBody>

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,10 @@ const theme = createTheme({
     palette: {
         mode: 'dark',
         primary: {
-            main: '#c5851199'
+            main: '#7D0A04'
         },
         secondary: {
-            main: '#c5851199'
+            main: '#B04B17'
         }
     }
 });

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,10 @@ const theme = createTheme({
     palette: {
         mode: 'dark',
         primary: {
-            main: '#7D0A04'
+            main: '#740f87'
         },
         secondary: {
-            main: '#B04B17'
+            main: '#a38020'
         }
     }
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,12 +24,7 @@ export const category20Colors = [
 
 export function toCurrencyString(v) {
     const parsed = parseFloat(v);
-    const asStr = Math.abs(parsed).toLocaleString(
-        'EN-US',
-        {
-            minimumFractionDigits: 2
-        }
-    );
+    const asStr = Math.abs(parsed);
     return `£${asStr}`;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,12 +33,34 @@ export function toCurrencyString(v) {
     return `£${asStr}`;
 }
 
-export function toGainString(v) {
+export function toGainString(v, m) {
     const parsed = parseFloat(v);
-    const currencyStr = toCurrencyString(v);
-    if (parsed < 0) {
-        return `-${currencyStr}`;
+    const chg = (Math.abs(v) / 100) * m;
+    const parsedFixed = parsed.toFixed(2);
+    const currencyStr = toCurrencyString(chg);
+    if (parseFloat(m) === 0) {
+        return (
+            <div style={{ color: 'gray' }}>
+                +{currencyStr} (+0.00%)
+            </div>
+        );
+    } else if (parsed < 0) {
+        return (
+            <div style={{ color: 'red' }}>
+                -{currencyStr} ({parsedFixed}%)
+            </div>
+        );
+    } else if (parsed > 0) {
+        return (
+            <div style={{ color: 'green' }}>
+                +{currencyStr} (+{parsedFixed}%)
+            </div>
+        );
     } else {
-        return `+${currencyStr}`;
+        return (
+            <div style={{ color: 'gray' }}>
+                +{currencyStr} (+{parsedFixed}%)
+            </div>
+        );
     }
 }


### PR DESCRIPTION
Updated the fields stored on ticker prices (now also persist market volume and 24 hour change). Also added a list holdings view which also includes the most recent ticker price for said holding.

UI overhaul / updates for list holdings and view holdings pages.

Added an INSERT to the create-holding lambda which creates a single current ticker price (so that things like volume that are not returned from historical data can be seen). Also adjusted historical data PG COPY to allow null values, 

Changed utils functions: `toCurrencyString` now doesn't do any rounding due to SHIB being rounded down to 0.00. `toGainString`'s logic updated and now returns coloured text based on gain positive / negative / zero.