### PR TITLE
ENH: compute units and gain & snackbar

### DIFF
--- a/cdk_back/lambdas/create-transaction/app.js
+++ b/cdk_back/lambdas/create-transaction/app.js
@@ -16,6 +16,8 @@ exports.handler = async (event, context) => {
         const client = new Client();
         await client.connect();
 
+        const txId = `${uuidv4()}`
+
         // Insert transaction row
         const insertTransactionQuery = `
             INSERT INTO transactions (
@@ -26,7 +28,7 @@ exports.handler = async (event, context) => {
                 units,
                 price
             ) VALUES (
-                '${uuidv4()}',
+                '${txId}',
                 '${requestData.holdingId}',
                 '${new Date(requestData.datetime).toISOString()}',
                 '${requestData.buySell}',
@@ -54,8 +56,17 @@ exports.handler = async (event, context) => {
 
         await client.end();
 
+        const responseData = {
+            buy_sell: `${requestData.buySell}`,
+            datetime: new Date(requestData.datetime).toISOString(),
+            holding_id: `${requestData.holdingId}`,
+            price: `${requestData.price}`,
+            tx_id: `${txId}`,
+            units: `${requestData.units}`,
+        }
+
         response.statusCode = 200;
-        response.body = "Success";
+        response.body = JSON.stringify(responseData);
     } catch (err) {
         console.log(err);
         response.statusCode = 500;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "finance-dash-server",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "finance-dash-server",
-    "version": "0.11.0",
+    "version": "0.12.0",
     "private": true,
     "dependencies": {
         "@emotion/react": "^11.7.1",

--- a/src/components/ClippedDrawer.js
+++ b/src/components/ClippedDrawer.js
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
   },
   navItemSelected: {
     // backgroundColor: theme.palette.secondary.main,
-    background: 'linear-gradient(0deg, rgba(74,57,13,1) 0%, rgba(163,128,32,1) 100%)'
+    background: 'linear-gradient(0deg, #0a093a 0%, #2421b7 100%)'
   },
   nested: {
     paddingLeft: theme.spacing(4),

--- a/src/components/CreateTransactionDialog.js
+++ b/src/components/CreateTransactionDialog.js
@@ -53,9 +53,10 @@ export default function CreateTransactionDialog(props) {
             data
         ).then(res => {
             console.log(res);
+            props.setTransactions([...props.transactions, res.data])
+            setOpen(false);
+            props.snackbarRef.current.handleClick();
         });
-        setOpen(false);
-        props.snackbarRef.current.handleClick();
         // props.
     }
 

--- a/src/components/CreateTransactionDialog.js
+++ b/src/components/CreateTransactionDialog.js
@@ -37,6 +37,10 @@ export default function CreateTransactionDialog(props) {
     };
 
     const handleClose = () => {
+        setOpen(false);
+    };
+
+    const handleSubmit = () => {
         const data = {
             holdingId: props.holdingId,
             datetime: date,
@@ -51,7 +55,9 @@ export default function CreateTransactionDialog(props) {
             console.log(res);
         });
         setOpen(false);
-    };
+        props.snackbarRef.current.handleClick();
+        // props.
+    }
 
   return (
       <div>
@@ -108,10 +114,18 @@ export default function CreateTransactionDialog(props) {
                   </FormControl>
               </DialogContent>
           <DialogActions>
-            <Button onClick={handleClose} color="primary">
+            <Button
+                onClick={handleClose}
+                color="primary"
+                variant="contained"
+            >
               Cancel
             </Button>
-            <Button onClick={handleClose} color="primary">
+            <Button
+                onClick={handleSubmit}
+                color="primary"
+                variant="contained"
+            >
               Add
             </Button>
           </DialogActions>

--- a/src/components/CustomSnackBar.js
+++ b/src/components/CustomSnackBar.js
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import MuiAlert from '@mui/material/Alert';
+
+const Alert = React.forwardRef(function Alert(props, ref) {
+  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
+});
+
+export const CustomSnackBar = React.forwardRef(function CustomSnackBar(props, ref) {
+    const [open, setOpen] = React.useState(false);
+
+    React.useImperativeHandle(ref, () => ({
+        handleClick() {
+            setOpen(true);
+        }
+    }))
+
+    const handleClick = () => {
+      setOpen(true);
+    };
+  
+    const handleClose = (event, reason) => {
+      if (reason === 'clickaway') {
+        return;
+      }
+      setOpen(false);
+    };
+  
+    return (
+      <Snackbar
+          open={open}
+          autoHideDuration={6000}
+          onClose={handleClose}
+          openFunction={handleClick}
+      >
+          <Alert onClose={handleClose} severity="success" sx={{ width: '100%' }}>
+              Transaction added successfully
+          </Alert>
+      </Snackbar>
+    );
+});
+
+// export default function CustomSnackBar() {
+
+// }

--- a/src/components/HoldingPriceChart/AreaChart.js
+++ b/src/components/HoldingPriceChart/AreaChart.js
@@ -38,7 +38,6 @@ export default function AreaChart({
     children,
     chartColor,
 }) {
-    console.log(circlesData);
     const {
         tooltipData,
         tooltipLeft,

--- a/src/components/HoldingView.js
+++ b/src/components/HoldingView.js
@@ -96,6 +96,9 @@ export default function HoldingView() {
 
     const [contentLoading, setContentLoading] = useState(true);
 
+    // refresh content e.g. after a new transaction is added
+    const [refreshRequired, setRefreshRequired] = useState(false);
+
     const snackbarRef = useRef();
 
     useEffect(() => {
@@ -219,14 +222,13 @@ export default function HoldingView() {
                                 twentyFour={twentyFourHrChange}
                                 holdingId={holdingId}
                                 snackbarRef={snackbarRef}
-                                // openSnackFunc={snackbarRef.current.handleClick()}
+                                setTransactions={setTransactions}
                             ></TransactionsTable>
                             <HoldingPriceChart 
                                 data={tickerPrices}
                                 circlesData={circlesData}
                                 chartColor={holdingColor}
                             ></HoldingPriceChart>
-                            <Button onClick={() => snackbarRef.current.handleClick()}>Click me</Button>
                             <CustomSnackBar ref={snackbarRef} />
                         </div>
                     </div>

--- a/src/components/HoldingView.js
+++ b/src/components/HoldingView.js
@@ -3,13 +3,14 @@ import makeStyles from '@mui/styles/makeStyles';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
 import Typography from '@mui/material/Typography';
-import { Button, Divider } from '@mui/material';
+import { Divider } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import TransactionsTable from './TransactionsTable';
 import { toCurrencyString, toGainString } from '../utils';
 import HoldingPriceChart from './HoldingPriceChart/HoldingPriceChart';
 import ContentLoading from './ContentLoading';
 import { CustomSnackBar } from './CustomSnackBar';
+import { getUnits, getPurchasePrice, getMVTotalGain } from '../utils/holding'
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -83,7 +84,6 @@ export default function HoldingView() {
 
     const [name, setName] = useState('');
     const [symbol, setSymbol] = useState('');
-    const [units, setUnits] = useState(0);
     const [currentPrice, setCurrentPrice] = useState(0);
     const [imageUrl, setImageUrl] = useState('');
     const [tickerPrices, setTickerPrices] = useState([]);
@@ -96,9 +96,6 @@ export default function HoldingView() {
 
     const [contentLoading, setContentLoading] = useState(true);
 
-    // refresh content e.g. after a new transaction is added
-    const [refreshRequired, setRefreshRequired] = useState(false);
-
     const snackbarRef = useRef();
 
     useEffect(() => {
@@ -109,7 +106,6 @@ export default function HoldingView() {
             console.log(res);
             setName(res.data.holding.ticker_name);
             setSymbol(res.data.holding.ticker_symbol);
-            setUnits(res.data.holding.units);
             setImageUrl(res.data.holding.image_url);
             setTickerPrices(res.data.tickerPrices.map((p) => {
                 return [new Date(p.datetime), parseFloat(p.price)]
@@ -192,28 +188,48 @@ export default function HoldingView() {
                                         <div style={{ flex: 1 }} className={classes.coinPricesLabel}>
                                             <Typography variant='h6'>Units</Typography>
                                         </div>
-                                        <div style={{ flex: 1 }}>
-                                            <Typography variant='h6'>{units}</Typography>
+                                        <div style={{ flex: 2 }}>
+                                            <Typography variant='h6'>{getUnits(transactions)}</Typography>
                                         </div>
                                     </div>
                                     <div style={{ display: 'flex', flex: 1 }}>
                                         <div style={{ flex: 1 }} className={classes.coinPricesLabel}>
                                             <Typography variant='h6'>Market value</Typography>
                                         </div>
-                                        <div style={{ flex: 1 }}>
+                                        <div style={{ flex: 2 }}>
                                             <Typography variant='h6'>
-                                                {toCurrencyString(units * currentPrice)}
+                                                {toCurrencyString(getUnits(transactions) * currentPrice)}
+                                            </Typography>
+                                        </div>
+                                    </div>
+                                    <div style={{ display: 'flex', flex: 1 }}>
+                                        <div style={{ flex: 1 }} className={classes.coinPricesLabel}>
+                                            <Typography variant='h6'>Market value 24h gain</Typography>
+                                        </div>
+                                        <div style={{ flex: 2 }}>
+                                            <Typography variant='h6'>
+                                                {toGainString(
+                                                    parseFloat(twentyFourHrChange),
+                                                    getPurchasePrice(transactions)
+                                                )}
+                                            </Typography>
+                                        </div>
+                                    </div>
+                                    <div style={{ display: 'flex', flex: 1 }}>
+                                        <div style={{ flex: 1 }} className={classes.coinPricesLabel}>
+                                            <Typography variant='h6'>Market value total gain</Typography>
+                                        </div>
+                                        <div style={{ flex: 2 }}>
+                                            <Typography variant='h6'>
+                                                {toGainString(
+                                                    (100 * getMVTotalGain(transactions, currentPrice) / getPurchasePrice(transactions)),
+                                                    getPurchasePrice(transactions)
+                                                )}
                                             </Typography>
                                         </div>
                                     </div>
                                 </div>
                                 <div style={{ flex: 1, display: 'flex' }}>
-                                    <div style={{ flex: 1 }}>
-                                        <Typography variant='body1'>Price</Typography>
-                                    </div>
-                                    <div style={{ flex: 1 }}>
-                                        <Typography variant='body1'>{toCurrencyString(currentPrice)}</Typography>
-                                    </div>
                                 </div>
                             </div>
                             <TransactionsTable 

--- a/src/components/HoldingView.js
+++ b/src/components/HoldingView.js
@@ -116,7 +116,7 @@ export default function HoldingView() {
             setHoldingColor(res.data.holding.color);
 
             const recentTP = res.data.tickerPrices[res.data.tickerPrices.length - 1];
-            console.log(recentTP);
+            // console.log(recentTP);
             setCurrentPrice(recentTP.price);
             setTwentyFourHrChange(recentTP.twenty_four_hour_change);
             setMarketCap(recentTP.market_cap);

--- a/src/components/HoldingView.js
+++ b/src/components/HoldingView.js
@@ -1,14 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
 import Typography from '@mui/material/Typography';
-import { Divider } from '@mui/material';
+import { Button, Divider } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import TransactionsTable from './TransactionsTable';
 import { toCurrencyString, toGainString } from '../utils';
 import HoldingPriceChart from './HoldingPriceChart/HoldingPriceChart';
 import ContentLoading from './ContentLoading';
+import { CustomSnackBar } from './CustomSnackBar';
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -94,6 +95,8 @@ export default function HoldingView() {
     const [circlesData, setCirclesData] = useState([]);
 
     const [contentLoading, setContentLoading] = useState(true);
+
+    const snackbarRef = useRef();
 
     useEffect(() => {
         // console.log(`Content loading ${contentLoading}`)
@@ -215,12 +218,16 @@ export default function HoldingView() {
                                 currentPrice={currentPrice}
                                 twentyFour={twentyFourHrChange}
                                 holdingId={holdingId}
+                                snackbarRef={snackbarRef}
+                                // openSnackFunc={snackbarRef.current.handleClick()}
                             ></TransactionsTable>
                             <HoldingPriceChart 
                                 data={tickerPrices}
                                 circlesData={circlesData}
                                 chartColor={holdingColor}
-                            />
+                            ></HoldingPriceChart>
+                            <Button onClick={() => snackbarRef.current.handleClick()}>Click me</Button>
+                            <CustomSnackBar ref={snackbarRef} />
                         </div>
                     </div>
                 </div>

--- a/src/components/HoldingsList/HoldingsListView.js
+++ b/src/components/HoldingsList/HoldingsListView.js
@@ -19,8 +19,10 @@ export default function HoldingsListView() {
         const endpoint = `${process.env.REACT_APP_FINANCE_DASH_API_ENDPOINT}holdings/list`;
         axios.get(endpoint)
         .then(res => {
+            console.log("RES", res);
             setHoldings(res.data.items);
             setContentLoading(false);
+            
         });
     }, []);
 

--- a/src/components/HoldingsList/HoldingsTable.js
+++ b/src/components/HoldingsList/HoldingsTable.js
@@ -21,6 +21,7 @@ import Tooltip from '@mui/material/Tooltip';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { toCurrencyString, toGainString } from '../../utils';
 import CreateHoldingDialog from './CreateHoldingDialog';
+import { getMVTotalGain, getPurchasePrice, getUnits } from '../../utils/holding';
 
 
 function createData(id, name, symbol, units, currentPrice, marketValue) {
@@ -324,12 +325,22 @@ export default function HoldingsTable(props) {
                                         </TableCell>
                                         <TableCell>{row.ticker_symbol}</TableCell>
                                         <TableCell>{row.ticker_name}</TableCell>
-                                        <TableCell>{row.units}</TableCell>
+                                        <TableCell>{getUnits(row.transactions)}</TableCell>
                                         <TableCell>{toCurrencyString(row.ticker_price)}</TableCell>
                                         <TableCell>{toGainString(row.ticker_twenty_four_change, row.ticker_price)}</TableCell>
-                                        <TableCell>{toCurrencyString(row.market_value)}</TableCell>
-                                        <TableCell>{toGainString(row.ticker_twenty_four_change, row.market_value)}</TableCell>
-                                        <TableCell>{toGainString(row.ticker_twenty_four_change, row.market_value)}</TableCell>
+                                        <TableCell>{toCurrencyString(getUnits(row.transactions) * row.ticker_price)}</TableCell>
+                                        <TableCell>
+                                            {toGainString(
+                                                    parseFloat(row.ticker_twenty_four_change),
+                                                    getPurchasePrice(row.transactions)
+                                            )}
+                                        </TableCell>
+                                        <TableCell>
+                                            {toGainString(
+                                                    (100 * getMVTotalGain(row.transactions, row.ticker_price) / getPurchasePrice(row.transactions)),
+                                                    getPurchasePrice(row.transactions)
+                                            )}
+                                        </TableCell>
                                         </TableRow>
                                     );
                                 }

--- a/src/components/HoldingsList/HoldingsTable.js
+++ b/src/components/HoldingsList/HoldingsTable.js
@@ -59,15 +59,15 @@ function stableSort(array, comparator) {
 
 
 const headCells = [
-    { id: 'logo', numeric: false, disablePadding: false, label: '', width: '25px' },
-    { id: 'symbol', numeric: false, disablePadding: false, label: 'Symbol' },
-    { id: 'name', numeric: false, disablePadding: false, label: 'Name' },
-    { id: 'units', numeric: false, disablePadding: false, label: 'Units' },
-    { id: 'ticker_price', numeric: false, disablePadding: false, label: 'Price' },
-    { id: 'ticker_twenty_four_change', numeric: false, disablePadding: false, label: 'Price 24h' },
-    { id: 'market_value', numeric: false, disablePadding: false, label: 'Market value'},
-    { id: 'market_value_twenty_four_change', numeric: false, disablePadding: false, label: 'Gain 24h'},
-    { id: 'market_value_total_change', numeric: false, disablePadding: false, label: 'Gain total'},
+    { id: 'logo', numeric: false, disablePadding: false, label: '', width: '5%' },
+    { id: 'symbol', numeric: false, disablePadding: false, label: 'Symbol', width: '5%' },
+    { id: 'name', numeric: false, disablePadding: false, label: 'Name', width: '15%' },
+    { id: 'units', numeric: false, disablePadding: false, label: 'Units', width: '12.5%' },
+    { id: 'ticker_price', numeric: false, disablePadding: false, label: 'Price', width: '12.5%' },
+    { id: 'ticker_twenty_four_change', numeric: false, disablePadding: false, label: 'Price 24h', width: '12.5%' },
+    { id: 'market_value', numeric: false, disablePadding: false, label: 'Market value', width: '12.5%' },
+    { id: 'market_value_twenty_four_change', numeric: false, disablePadding: false, label: 'Gain 24h', width: '12.5%' },
+    { id: 'market_value_total_change', numeric: false, disablePadding: false, label: 'Gain total', width: '12.5%' },
 ];
 
 

--- a/src/components/TransactionsTable.js
+++ b/src/components/TransactionsTable.js
@@ -341,11 +341,7 @@ export default function TransactionsTable(props) {
                                         <TableCell align="right">{toCurrencyString(row.price)}</TableCell>
                                         <TableCell align="right">{toCurrencyString(row.currentPrice)}</TableCell>
                                         <TableCell align="right">{toGainString(row.twentyFour, row.price)}</TableCell>
-                                        <TableCell align="right">{toGainString((100 * row.totalGain / row.price), row.price)}
-                                            
-                                            
-                                            {/* {`${toCurrencyString(row.totalGain)} (${(100 * row.totalGain / row.price).toFixed(2)}%)`} */}
-                                            </TableCell>
+                                        <TableCell align="right">{toGainString((100 * row.totalGain / row.price), row.price)}</TableCell>
                                         </TableRow>
                                     );
                                 }

--- a/src/components/TransactionsTable.js
+++ b/src/components/TransactionsTable.js
@@ -179,7 +179,10 @@ const EnhancedTableToolbar = (props) => {
             </Tooltip>
         )}
 
-        <CreateTransactionDialog holdingId={props.holdingId}></CreateTransactionDialog>
+        <CreateTransactionDialog
+            holdingId={props.holdingId}
+            snackbarRef={props.snackbarRef}
+        ></CreateTransactionDialog>
     </Toolbar>
     );
 };
@@ -286,6 +289,7 @@ export default function TransactionsTable(props) {
                     selected={selected}
                     numSelected={selected.length}
                     holdingId={props.holdingId}
+                    snackbarRef={props.snackbarRef}
                 />
                 <TableContainer>
                     <Table

--- a/src/components/TransactionsTable.js
+++ b/src/components/TransactionsTable.js
@@ -182,6 +182,8 @@ const EnhancedTableToolbar = (props) => {
         <CreateTransactionDialog
             holdingId={props.holdingId}
             snackbarRef={props.snackbarRef}
+            setTransactions={props.setTransactions}
+            transactions={props.transactions}
         ></CreateTransactionDialog>
     </Toolbar>
     );
@@ -290,6 +292,8 @@ export default function TransactionsTable(props) {
                     numSelected={selected.length}
                     holdingId={props.holdingId}
                     snackbarRef={props.snackbarRef}
+                    setTransactions={props.setTransactions}
+                    transactions={props.transactions}
                 />
                 <TableContainer>
                     <Table

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const theme = createTheme({
             main: '#740f87'
         },
         secondary: {
-            main: '#a38020'
+            main: '#2421b7'
         }
     }
 });

--- a/src/utils/holding.js
+++ b/src/utils/holding.js
@@ -1,0 +1,13 @@
+export const getUnits = (transactions) => {
+    return transactions.reduce((a, b) => a + parseFloat(b.units), 0);
+}
+
+export const getPurchasePrice = (transactions) => {
+    return transactions.reduce((a, b) => a + parseFloat(b.price), 0);
+}
+
+export const getMVTotalGain = (transactions, currentPrice) => {
+    const txGains = transactions.map((t) => (currentPrice * parseFloat(t.units)) - parseFloat(t.price));
+    console.log(txGains.reduce((a, b) => a + b, 0))
+    return txGains.reduce((a, b) => a + b, 0);
+}


### PR DESCRIPTION
Changes to the holding list view:
- Now pulls transactions and uses them to determine units / gains.
- Column widths in table are explicitly set.

Fixed the holding price chart to correctly show a year's worth of data (instead of the last 365 data items).

Changed the add transaction dialog to show a snackbar (toast) on completion and now updates state of the transactions in react. In order to do this the add transaction lambda needed to include a copy of the inserted transaction in the API response. Changed secondary theme colour from yellow to blue.