### PR TITLE
ENH: profile identicons & logout and S3 `autoDeleteObjects`

### DIFF
--- a/cdk_front/lib/finance-dash-stack.ts
+++ b/cdk_front/lib/finance-dash-stack.ts
@@ -14,6 +14,7 @@ export class FinanceDashStack extends Stack {
             websiteIndexDocument: 'index.html',
             publicReadAccess: true,
             removalPolicy: RemovalPolicy.DESTROY,
+            autoDeleteObjects: true,
         });
 
         const distribution = new Distribution(this, 'CloudDist', {
@@ -42,7 +43,7 @@ export class FinanceDashStack extends Stack {
                     implicitCodeGrant: true,
                 },
                 callbackUrls: [
-                    `https://${distribution.domainName}/home`
+                    `https://${distribution.domainName}/dashboard`
                 ]
             },
         });
@@ -54,7 +55,7 @@ export class FinanceDashStack extends Stack {
         });
 
         const signInUrl = domain.signInUrl(userPoolClient, {
-            redirectUri: `https://${distribution.domainName}/home`
+            redirectUri: `https://${distribution.domainName}/dashboard`
         });
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "finance-dash-server",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -8737,6 +8737,11 @@
             "requires": {
                 "postcss": "^7.0.14"
             }
+        },
+        "identicon.js": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/identicon.js/-/identicon.js-2.3.3.tgz",
+            "integrity": "sha512-/qgOkXKZ7YbeCYbawJ9uQQ3XJ3uBg9VDpvHjabCAPp6aRMhjLaFAxG90+1TxzrhKaj6AYpVGrx6UXQfQA41UEA=="
         },
         "identity-obj-proxy": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "finance-dash-server",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "private": true,
     "dependencies": {
         "@emotion/react": "^11.7.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@visx/xychart": "^2.1.0",
         "amazon-cognito-identity-js": "^5.2.3",
         "axios": "^0.21.1",
+        "identicon.js": "^2.3.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.2.0",

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -13,14 +13,16 @@ const Account = (props) => {
                     if (err) {
                         reject();
                     } else {
+                        console.log("Resoving");
                         resolve(session);
                     }
                 })
             } else {
+                console.log("Rejecting");
                 reject();
             }
         })
-    } 
+    };
 
     const authenticate = async (Username, Password) => {
         return await new Promise((resolve, reject) => {
@@ -45,8 +47,16 @@ const Account = (props) => {
         });
     };
 
+    const logout = () => {
+        console.log("Logging out");
+        const user = Pool.getCurrentUser();
+        if (user) {
+            user.signOut();
+        }
+    };
+
     return (
-        <AccountContext.Provider value={{ authenticate, getSession }}>
+        <AccountContext.Provider value={{ authenticate, getSession, logout }}>
             {props.children}
         </AccountContext.Provider>
     )

--- a/src/components/ClippedDrawer.js
+++ b/src/components/ClippedDrawer.js
@@ -20,6 +20,7 @@ import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
 import HoldingsListView from './HoldingsList/HoldingsListView';
 import HoldingView from './HoldingView';
 import Dashboard from './Dashboard';
+import Status from './Status';
 
 const drawerWidth = 240;
 
@@ -52,6 +53,9 @@ const useStyles = makeStyles((theme) => ({
   nested: {
     paddingLeft: theme.spacing(4),
   },
+  titleText: {
+      flex: 1
+  },
 }));
 
 export default function ClippedDrawer() {
@@ -63,12 +67,14 @@ export default function ClippedDrawer() {
             <CssBaseline />
             <AppBar position="fixed" className={classes.appBar}>
                 <Toolbar>
-                <Typography 
-                    variant="h6" 
-                    noWrap
-                >
-                    Investment Tracker
-                </Typography>
+                    <Typography
+                        className={classes.titleText}
+                        variant="h6" 
+                        noWrap
+                    >
+                        Investment Tracker
+                    </Typography>
+                    <Status />
                 </Toolbar>
             </AppBar>
             <Drawer

--- a/src/components/ClippedDrawer.js
+++ b/src/components/ClippedDrawer.js
@@ -21,6 +21,7 @@ import HoldingsListView from './HoldingsList/HoldingsListView';
 import HoldingView from './HoldingView';
 import Dashboard from './Dashboard';
 import Status from './Status';
+import Login from './Login';
 
 const drawerWidth = 240;
 
@@ -47,7 +48,6 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(3),
   },
   navItemSelected: {
-    // backgroundColor: theme.palette.secondary.main,
     background: 'linear-gradient(0deg, #0a093a 0%, #2421b7 100%)'
   },
   nested: {
@@ -121,6 +121,9 @@ export default function ClippedDrawer() {
                     </Route>
                     <Route path="/dashboard">
                         <Dashboard />
+                    </Route>
+                    <Route path="/login">
+                        <Login />
                     </Route>
                 </Switch>
             </main>

--- a/src/components/HoldingsList/HoldingsListView.js
+++ b/src/components/HoldingsList/HoldingsListView.js
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import Paper from '@mui/material/Paper';
 import axios from 'axios';
 import HoldingsTable from './HoldingsTable';
 import ContentLoading from '../ContentLoading';
-
+import { AccountContext } from "../Account";
+import  { Redirect } from 'react-router-dom'
 
 const useStyles = makeStyles((theme) => ({}));
 
@@ -14,23 +15,37 @@ export default function HoldingsListView() {
 
     const [holdings, setHoldings] = useState([]);
     const [contentLoading, setContentLoading] = useState(true);
+    const [authFailed, setAuthFailed] = useState(false);
+
+    const { getSession } = useContext(AccountContext);
 
     useEffect(() => {
-        const endpoint = `${process.env.REACT_APP_FINANCE_DASH_API_ENDPOINT}holdings/list`;
-        axios.get(endpoint)
-        .then(res => {
-            console.log(res);
-            setHoldings(res.data.items);
-            setContentLoading(false); 
-        });
-    }, []);
+        getSession()
+            .then((session) => {
+                console.log(`Authenticated with session ${session}`);
+                const endpoint = `${process.env.REACT_APP_FINANCE_DASH_API_ENDPOINT}holdings/list`;
+                axios.get(endpoint)
+                    .then(res => {
+                        console.log(res);
+                        setHoldings(res.data.items);
+                        setContentLoading(false); 
+                    });
+            })
+            .catch((err) => {
+                setAuthFailed(true);
+                console.log("Not authenticated. Redirecting")
+            });
+    }, [getSession]);
 
+    if (authFailed) {
+        return <Redirect to='/login' />
+    }
 
     return (
         <>
             {contentLoading? (
                 <ContentLoading />
-            ): (
+            ) : (
                 <div className={classes.root} component={Paper}>
                     <HoldingsTable
                         holdings={holdings}

--- a/src/components/Status.js
+++ b/src/components/Status.js
@@ -1,16 +1,48 @@
 import React, { useState, useContext, useEffect } from "react";
 import { AccountContext } from "./Account";
+// import { toSvg } from "jdenticon";
+import Identicon from "identicon.js";
+import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 
 const Status = () => {
-    const [status, setStatus] = useState(false);
+    const [svgString, setSvgString] = useState("");
 
-    const { getSession } = useContext(AccountContext);
+    const { getSession, logout } = useContext(AccountContext);
+
+    const [anchorEl, setAnchorEl] = React.useState(null);
+    const open = Boolean(anchorEl);
+
+    const handleClick = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    const handleLogout = () => {
+        logout();
+        setAnchorEl(null);
+    };
 
     useEffect(() => {
         getSession()
             .then((session) => {
                 console.log("Session", session);
-                setStatus(true);
+                var options = {
+                    foreground: [0, 0, 0, 255],               // rgba black
+                    background: [255, 255, 255, 255],         // rgba white
+                    margin: 0.2,                              // 20% margin
+                    size: 40,                                // 420px square
+                    format: 'svg'                             // use SVG instead of PNG
+                };
+                const initSvgStr = new Identicon(session.idToken.payload.sub, options).toString();
+                console.log(initSvgStr)
+                setSvgString(
+                    '<img style="border-radius: 50%" width=40 height=40 src="data:image/svg+xml;base64,' + initSvgStr + '">'
+                );
             })
             .catch((err) => {
                 console.error(err);
@@ -19,7 +51,34 @@ const Status = () => {
 
     return (
         <div>
-            {status ? "Logged in" : "Not logged in"}
+            <Button
+                id="basic-button"
+                aria-controls={open ? 'basic-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                onClick={handleClick}
+            >
+                <div dangerouslySetInnerHTML={{ __html: svgString }} />
+            </Button>
+            <Menu
+                id="basic-menu"
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleClose}
+                MenuListProps={{
+                    'aria-labelledby': 'basic-button',
+                }}
+                anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'right',
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right',
+                }}
+            >
+                <MenuItem onClick={handleLogout}>Logout</MenuItem>
+            </Menu>
         </div>
     )
 };

--- a/src/components/Status.js
+++ b/src/components/Status.js
@@ -5,8 +5,10 @@ import Identicon from "identicon.js";
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import { useHistory } from 'react-router-dom';
 
 const Status = () => {
+    let history = useHistory();
     const [svgString, setSvgString] = useState("");
 
     const { getSession, logout } = useContext(AccountContext);
@@ -25,6 +27,7 @@ const Status = () => {
     const handleLogout = () => {
         logout();
         setAnchorEl(null);
+        history.push("/login");
     };
 
     useEffect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -22,10 +22,12 @@ const theme = createTheme({
 });
 
 ReactDOM.render(
-  <React.StrictMode>
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={theme}>
-        <ClippedDrawer />
+    <React.StrictMode>
+        <StyledEngineProvider injectFirst>
+            <ThemeProvider theme={theme}>
+                <Account>
+                    <ClippedDrawer />
+                </Account>
         {/* <Account>
             <Status />
             <Login />


### PR DESCRIPTION
Adds identicon (similar to github default profile picture) which are created based on the AWS cognito account "sub" ID. Also adds a drop down menu when the identicon is clicked which gives an option to logout. 

Set `autoDeleteObjects` property on S3 bucket in CDK so that it can be deleted along with the rest of the stack without needing to manually empty first.